### PR TITLE
Windows sandbox support.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@ cef-build-debug = "run --bin cef-build --release -- --profile dev"
 cef-build-release = "run --bin cef-build --release -- --profile release"
 cef-clean = "run --bin cef-clean --release"
 cef-artifacts = "run --bin cef-artifacts --release"
+
+[env]
+CEF_ARTIFACTS_DIR = { value = "artifacts", force = true }

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 
 # Ignore JetBrains files.
 .idea/
+
+# Ignore CEF-generated files.
+MediaDeviceSalts*

--- a/crates/cef-ui-helper/Cargo.toml
+++ b/crates/cef-ui-helper/Cargo.toml
@@ -3,10 +3,6 @@ name = "cef-ui-helper"
 version = "0.1.0"
 edition = "2021"
 
-[features]
-sandbox = []
-default = ["sandbox"]
-
 [dependencies]
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/cef-ui-helper/src/run.rs
+++ b/crates/cef-ui-helper/src/run.rs
@@ -20,8 +20,8 @@ use tracing_subscriber::FmtSubscriber;
 const CEF_PATH: &str = "../../../Chromium Embedded Framework.framework/Chromium Embedded Framework";
 
 /// Returns the CEF error code or 1 if an error occurred.
-pub fn run() {
-    let ret = try_run().unwrap_or_else(|e| {
+pub fn run(sandbox: bool) {
+    let ret = try_run(sandbox).unwrap_or_else(|e| {
         error!("An error occurred: {}", e);
 
         1
@@ -33,7 +33,7 @@ pub fn run() {
 }
 
 /// Try and run the helper, returning the CEF error code if successful.
-fn try_run() -> Result<i32> {
+fn try_run(sandbox: bool) -> Result<i32> {
     // This routes log macros through tracing.
     LogTracer::init()?;
 
@@ -45,8 +45,10 @@ fn try_run() -> Result<i32> {
     set_global_default(subscriber)?;
 
     // Setup the sandbox if enabled.
-    #[cfg(feature = "sandbox")]
-    let _sandbox = ScopedSandbox::new()?;
+    let _sandbox = match sandbox {
+        true => Some(ScopedSandbox::new()?),
+        false => None
+    };
 
     // Manually load CEF and execute the subprocess.
     let ret = unsafe {

--- a/crates/cef-ui-simple-helper/build.rs
+++ b/crates/cef-ui-simple-helper/build.rs
@@ -1,11 +1,8 @@
 use anyhow::Result;
-use cef_ui_util::{get_build_rs_workspace_dir, link_cef_helper};
+use cef_ui_util::link_cef_helper;
 
 fn main() -> Result<()> {
-    let workspace_dir = get_build_rs_workspace_dir()?;
-    let artifacts_dir = workspace_dir.join("artifacts");
-
-    link_cef_helper(&artifacts_dir)?;
+    link_cef_helper()?;
 
     Ok(())
 }

--- a/crates/cef-ui-simple-helper/src/main.rs
+++ b/crates/cef-ui-simple-helper/src/main.rs
@@ -1,5 +1,5 @@
 use cef_ui_helper::run;
 
 fn main() {
-    run();
+    run(true);
 }

--- a/crates/cef-ui-simple/Cargo.toml
+++ b/crates/cef-ui-simple/Cargo.toml
@@ -4,10 +4,6 @@ version = "0.1.0"
 edition = "2021"
 build = "build.rs"
 
-[features]
-sandbox = []
-default = ["sandbox"]
-
 [build-dependencies]
 cef-ui-util = { path = "../cef-ui-util" }
 anyhow = { workspace = true }

--- a/crates/cef-ui-simple/build.rs
+++ b/crates/cef-ui-simple/build.rs
@@ -1,11 +1,8 @@
 use anyhow::Result;
-use cef_ui_util::{get_build_rs_workspace_dir, link_cef};
+use cef_ui_util::link_cef;
 
 fn main() -> Result<()> {
-    let workspace_dir = get_build_rs_workspace_dir()?;
-    let artifacts_dir = workspace_dir.join("artifacts");
-
-    link_cef(&artifacts_dir)?;
+    link_cef()?;
 
     Ok(())
 }

--- a/crates/cef-ui-tools/src/cef_artifacts.rs
+++ b/crates/cef-ui-tools/src/cef_artifacts.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use cef_ui_util::{get_tool_workspace_dir, ArtifactsCommand};
+use cef_ui_util::{get_tool_artifacts_dir, ArtifactsCommand};
 use tracing::{level_filters::LevelFilter, subscriber::set_global_default, Level};
 use tracing_log::LogTracer;
 use tracing_subscriber::FmtSubscriber;
@@ -15,8 +15,7 @@ fn main() -> Result<()> {
 
     set_global_default(subscriber)?;
 
-    let workspace_dir = get_tool_workspace_dir()?;
-    let artifacts_dir = workspace_dir.join("artifacts");
+    let artifacts_dir = get_tool_artifacts_dir()?;
 
     ArtifactsCommand { artifacts_dir }.run()?;
 

--- a/crates/cef-ui-tools/src/cef_build.rs
+++ b/crates/cef-ui-tools/src/cef_build.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use cef_ui_util::{get_tool_workspace_dir, AppBundleSettings, BuildCommand};
+use cef_ui_util::{
+    get_tool_artifacts_dir, get_tool_workspace_dir, AppBundleSettings, BuildCommand
+};
 use clap::Parser;
 use tracing::{level_filters::LevelFilter, subscriber::set_global_default, Level};
 use tracing_log::LogTracer;
@@ -46,7 +48,7 @@ fn main() -> Result<()> {
         // Build the app bundle.
         AppBundleSettings {
             profile:         args.profile.to_string(),
-            artifacts_dir:   workspace_dir.join("artifacts"),
+            artifacts_dir:   get_tool_artifacts_dir()?,
             app_name:        String::from("cef-ui-simple"),
             main_exe_name:   String::from("cef-ui-simple"),
             helper_exe_name: String::from("cef-ui-simple-helper"),

--- a/crates/cef-ui-tools/src/cef_clean.rs
+++ b/crates/cef-ui-tools/src/cef_clean.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use cef_ui_util::{get_tool_workspace_dir, CleanCommand};
+use cef_ui_util::{get_tool_artifacts_dir, get_tool_workspace_dir, CleanCommand};
 use tracing::{level_filters::LevelFilter, subscriber::set_global_default, Level};
 use tracing_log::LogTracer;
 use tracing_subscriber::FmtSubscriber;
@@ -15,8 +15,7 @@ fn main() -> Result<()> {
 
     set_global_default(subscriber)?;
 
-    let workspace_dir = get_tool_workspace_dir()?;
-    let artifacts_dir = workspace_dir.join("artifacts");
+    let artifacts_dir = get_tool_artifacts_dir()?;
 
     CleanCommand { artifacts_dir }.run()?;
 

--- a/crates/cef-ui-util/src/commands/artifacts.rs
+++ b/crates/cef-ui-util/src/commands/artifacts.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use bindgen::{builder, EnumVariation};
 use std::{
     env::consts::{ARCH, OS},
-    fs::{self, canonicalize, create_dir_all, remove_dir_all, remove_file, rename},
+    fs::{self, canonicalize, create_dir_all, remove_dir_all, rename},
     path::{Path, PathBuf},
     process::{Command, Stdio}
 };
@@ -236,7 +236,6 @@ impl ArtifactsCommand {
         if cfg!(target_os = "windows") {
             copy_files(&extracted_dir.join("Release"), &cef_dir)?;
             copy_files(&extracted_dir.join("Resources"), &cef_dir)?;
-            remove_file(&cef_dir.join("cef_sandbox.lib"))?;
         }
 
         // Create the tar gzipped file.

--- a/crates/cef-ui-util/src/link.rs
+++ b/crates/cef-ui-util/src/link.rs
@@ -47,7 +47,7 @@ pub fn link_cef() -> Result<()> {
 }
 
 /// Copy the CEF files to the target directory on Linux.
-#[cfg(target_os = "linux")]
+#[allow(dead_code)]
 fn copy_cef_linux() -> Result<()> {
     use crate::CEF_DIRECTORY;
 
@@ -61,7 +61,7 @@ fn copy_cef_linux() -> Result<()> {
 }
 
 /// Copy the CEF files to the target directory on Windows.
-#[cfg(target_os = "windows")]
+#[allow(dead_code)]
 fn copy_cef_windows() -> Result<()> {
     let src = get_build_rs_cef_dir()?;
     let dst = get_build_rs_target_dir()?;

--- a/crates/cef-ui-util/src/link.rs
+++ b/crates/cef-ui-util/src/link.rs
@@ -1,11 +1,14 @@
-use crate::{copy_files, download_and_extract_cef, get_build_rs_target_dir};
+use crate::{
+    copy_files, download_and_extract_cef, get_build_rs_artifacts_dir, get_build_rs_cef_dir,
+    get_build_rs_target_dir
+};
 use anyhow::Result;
-use std::path::Path;
 
 /// Call this in your binary crate's build.rs
 /// file to properly link against CEF.
-pub fn link_cef(artifacts_dir: &Path) -> Result<()> {
-    let cef_dir = artifacts_dir.join("cef");
+pub fn link_cef() -> Result<()> {
+    let artifacts_dir = get_build_rs_artifacts_dir()?;
+    let cef_dir = get_build_rs_cef_dir()?;
 
     // Download and extract the CEF binaries.
     download_and_extract_cef(&artifacts_dir)?;
@@ -14,7 +17,7 @@ pub fn link_cef(artifacts_dir: &Path) -> Result<()> {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     {
         // Copy the CEF binaries.
-        copy_cef_linux(artifacts_dir)?;
+        copy_cef_linux()?;
 
         // This tells Rust where to find libcef.so at compile time.
         println!("cargo:rustc-link-search=native={}", cef_dir.display());
@@ -34,7 +37,7 @@ pub fn link_cef(artifacts_dir: &Path) -> Result<()> {
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
     {
         // Copy the CEF binaries.
-        copy_cef_windows(artifacts_dir)?;
+        copy_cef_windows()?;
 
         // This tells Rust where to find libcef.lib at compile time.
         println!("cargo:rustc-link-search=native={}", cef_dir.display());
@@ -44,10 +47,12 @@ pub fn link_cef(artifacts_dir: &Path) -> Result<()> {
 }
 
 /// Copy the CEF files to the target directory on Linux.
-#[allow(dead_code)]
-fn copy_cef_linux(artifacts_dir: &Path) -> Result<()> {
-    let src = artifacts_dir.join("cef");
-    let dst = get_build_rs_target_dir()?.join("cef");
+#[cfg(target_os = "linux")]
+fn copy_cef_linux() -> Result<()> {
+    use crate::CEF_DIRECTORY;
+
+    let src = get_build_rs_cef_dir()?;
+    let dst = get_build_rs_target_dir()?.join(CEF_DIRECTORY);
 
     // Copy the CEF binaries.
     copy_files(&src, &dst)?;
@@ -56,9 +61,9 @@ fn copy_cef_linux(artifacts_dir: &Path) -> Result<()> {
 }
 
 /// Copy the CEF files to the target directory on Windows.
-#[allow(dead_code)]
-fn copy_cef_windows(artifacts_dir: &Path) -> Result<()> {
-    let src = artifacts_dir.join("cef");
+#[cfg(target_os = "windows")]
+fn copy_cef_windows() -> Result<()> {
+    let src = get_build_rs_cef_dir()?;
     let dst = get_build_rs_target_dir()?;
 
     // Copy the CEF binaries.
@@ -69,8 +74,9 @@ fn copy_cef_windows(artifacts_dir: &Path) -> Result<()> {
 
 /// Call this in your binary helper crate's build.rs file to
 /// properly link against the CEF sandbox static library.
-pub fn link_cef_helper(artifacts_dir: &Path) -> Result<()> {
-    let cef_dir = artifacts_dir.join("cef");
+pub fn link_cef_helper() -> Result<()> {
+    let artifacts_dir = get_build_rs_artifacts_dir()?;
+    let cef_dir = get_build_rs_cef_dir()?;
 
     // Download and extract the CEF binaries.
     download_and_extract_cef(&artifacts_dir)?;

--- a/crates/cef-ui-util/src/paths.rs
+++ b/crates/cef-ui-util/src/paths.rs
@@ -3,6 +3,18 @@ use anyhow::Result;
 use cargo_metadata::MetadataCommand;
 use std::{env::var, fs::canonicalize, path::PathBuf};
 
+/// The name of the artifacts directory environment variable.
+pub const CEF_ARTIFACTS_DIR: &str = "CEF_ARTIFACTS_DIR";
+
+/// The default artifacts directory, relative to the
+/// workspace root. You can customize this by setting
+/// the CEF_ARTIFACTS_DIR environment variable within
+/// the .cargo/config.toml file.
+pub const DEFAULT_CEF_ARTIFACTS_DIR: &str = "artifacts";
+
+/// The cef directory within the artifacts dir.
+pub const CEF_DIRECTORY: &str = "cef";
+
 /// Get the workspace directory. Only call within build.rs!
 pub fn get_build_rs_workspace_dir() -> Result<PathBuf> {
     let metadata = MetadataCommand::new().exec()?;
@@ -20,7 +32,22 @@ pub fn get_build_rs_target_dir() -> Result<PathBuf> {
     Ok(dir)
 }
 
-/// Get the workspace directory. Only call from tools.
+/// Get the artifacts dir. Only call within build.rs!
+pub fn get_build_rs_artifacts_dir() -> Result<PathBuf> {
+    let dir = get_build_rs_workspace_dir()?;
+    let dir = dir.join(var(CEF_ARTIFACTS_DIR).unwrap_or(DEFAULT_CEF_ARTIFACTS_DIR.into()));
+
+    Ok(dir)
+}
+
+/// Get the cef directory. Only call within build.rs!
+pub fn get_build_rs_cef_dir() -> Result<PathBuf> {
+    let dir = get_build_rs_artifacts_dir()?.join(CEF_DIRECTORY);
+
+    Ok(dir)
+}
+
+/// Get the workspace directory. Only call from tools!
 pub fn get_tool_workspace_dir() -> Result<PathBuf> {
     let dir = get_exe_dir()?.join("../..");
     let dir = canonicalize(dir)?;
@@ -28,13 +55,28 @@ pub fn get_tool_workspace_dir() -> Result<PathBuf> {
     Ok(dir)
 }
 
-/// Get the target directory. Only call from tools.
+/// Get the target directory. Only call from tools!
 pub fn get_tool_target_dir(profile: &str) -> Result<PathBuf> {
     let dir = get_tool_workspace_dir()?.join("target");
     let dir = match profile == "dev" {
         true => dir.join("debug"),
         false => dir.join(profile)
     };
+
+    Ok(dir)
+}
+
+/// Get the artifacts dir. Only call from tools!
+pub fn get_tool_artifacts_dir() -> Result<PathBuf> {
+    let dir = get_tool_workspace_dir()?;
+    let dir = dir.join(var(CEF_ARTIFACTS_DIR).unwrap_or(DEFAULT_CEF_ARTIFACTS_DIR.into()));
+
+    Ok(dir)
+}
+
+/// Get the cef directory. Only call from tools!
+pub fn get_tool_cef_dir() -> Result<PathBuf> {
+    let dir = get_tool_artifacts_dir()?.join(CEF_DIRECTORY);
 
     Ok(dir)
 }

--- a/crates/cef-ui/Cargo.toml
+++ b/crates/cef-ui/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 build = "build.rs"
 
+[build-dependencies]
+cef-ui-util = { path = "../cef-ui-util" }
+anyhow = { workspace = true }
+
 [dependencies]
 cef-ui-util = { path = "../cef-ui-util" }
 anyhow = { workspace = true }

--- a/crates/cef-ui/build.rs
+++ b/crates/cef-ui/build.rs
@@ -1,19 +1,39 @@
-fn main() {
+use anyhow::Result;
+
+fn main() -> Result<()> {
     // Linker flags on x86_64 Linux.
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     {
+        // Link dynamically to CEF.
         println!("cargo:rustc-link-lib=dylib=cef");
     }
 
     // Linker flags on arm64 macOS.
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     {
+        // Link dynamically to the CEF framework.
         println!("cargo:rustc-link-lib=framework=Chromium Embedded Framework");
     }
 
     // Linker flags on x86_64 Windows.
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
     {
+        use cef_ui_util::get_build_rs_cef_dir;
+
+        let cef_dir = get_build_rs_cef_dir()?;
+
+        // Link statically to the CEF sandbox.
+        println!("cargo:rustc-link-search=native={}", cef_dir.display());
+        println!("cargo:rustc-link-lib=static=cef_sandbox");
+
+        // Link dynamically to CEF.
         println!("cargo:rustc-link-lib=dylib=libcef");
+
+        // Link dynamically to CEF dependencies.
+        println!("cargo:rustc-link-lib=wbemuuid");
+        println!("cargo:rustc-link-lib=propsys");
+        println!("cargo:rustc-link-lib=delayimp");
     }
+
+    Ok(())
 }

--- a/crates/cef-ui/src/cef/context.rs
+++ b/crates/cef-ui/src/cef/context.rs
@@ -1,7 +1,7 @@
 use crate::{
     bindings::{
         cef_do_message_loop_work, cef_execute_process, cef_initialize, cef_quit_message_loop,
-        cef_run_message_loop, cef_sandbox_info_create, cef_sandbox_info_destroy, cef_shutdown
+        cef_run_message_loop, cef_shutdown
     },
     App, MainArgs, Settings
 };
@@ -135,6 +135,8 @@ impl Drop for Context {
 /// This function creates the windows sandbox info.
 #[cfg(target_os = "windows")]
 fn create_windows_sandbox_info(settings: &Settings) -> *mut c_void {
+    use crate::bindings::cef_sandbox_info_create;
+
     match settings.is_sandbox_enabled() {
         true => unsafe { cef_sandbox_info_create() },
         false => null_mut()
@@ -144,6 +146,8 @@ fn create_windows_sandbox_info(settings: &Settings) -> *mut c_void {
 /// This function destroys the windows sandbox info.
 #[cfg(target_os = "windows")]
 fn destroy_windows_sandbox_info(windows_sandbox_info: *mut c_void) {
+    use crate::bindings::cef_sandbox_info_destroy;
+
     if !windows_sandbox_info.is_null() {
         unsafe { cef_sandbox_info_destroy(windows_sandbox_info) };
     }
@@ -157,4 +161,4 @@ fn create_windows_sandbox_info(_settings: &Settings) -> *mut c_void {
 
 /// This function destroys the windows sandbox info.
 #[cfg(not(target_os = "windows"))]
-fn destroy_windows_sandbox_info(windows_sandbox_info: *mut c_void) {}
+fn destroy_windows_sandbox_info(_windows_sandbox_info: *mut c_void) {}

--- a/crates/cef-ui/src/cef/settings.rs
+++ b/crates/cef-ui/src/cef/settings.rs
@@ -34,6 +34,11 @@ impl Settings {
         self
     }
 
+    /// Returns true if the sandbox is enabled.
+    pub fn is_sandbox_enabled(&self) -> bool {
+        self.0.no_sandbox == 0
+    }
+
     /// The path to a separate executable that will be launched for sub-processes.
     /// If this value is empty on Windows or Linux then the main process
     /// executable will be used. If this value is empty on macOS then a helper


### PR DESCRIPTION
This PR adds Windows sandbox support. Specifically, this PR:

* Now sets the artifacts directory via the `CEF_ARTIFACTS_DIR` within `.cargo/config.toml`.
* Always links the sandbox at compile time for Windows and macOS.
* Simplifies linking for the main executable and the helper executable.
* Fixes cross-platform compilation issues.
* Updates `paths.rs` to automatically infer the artifacts directory given the `CEF_ARTIFACTS_DIR` variable.
* Updates `cef-ui` to properly link against the Windows sandbox statically at compile time.
* Updates `cef-ui` to properly link against the Windows sandbox dependencies at runtime.
* Updates `Context` to properly initialize and teardown the Windows sandbox if enabled.

This fixes #12.